### PR TITLE
Fixed issue with delete button going to the edit page

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -32,6 +32,7 @@
   integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65"
   crossorigin="anonymous"
 />
+    <link rel="stylesheet" href="styles.css">
     <title>Audio-X</title>
   </head>
   <body>

--- a/frontend/public/styles.css
+++ b/frontend/public/styles.css
@@ -1,0 +1,8 @@
+.delete-button-dashboard {
+    transition: all 200ms ease-in;
+    z-index: 10;
+}
+
+.delete-button-dashboard:hover {
+    background-color: rgb(172, 96, 134);
+}

--- a/frontend/src/components/Card.js
+++ b/frontend/src/components/Card.js
@@ -10,11 +10,7 @@ function Card(props){
     const linecolor = props.theme==="light" ? "#BCD5EB" : "#AC6086"
     const deleteColor = props.theme==="light" ? "#3B84CB" : "#F2D1DB"
     const handleEditButton = (e) => {
-        if(!e.target.classList.contains("delete-button-dashboard")){
-            // This if condition is to prevent the click event from being triggered when the delete button is clicked
-            console.log("edit button was clicked")
-            navigate("/editaudio", { state: { id: props.id, name:props.title } });
-        }
+        navigate("/editaudio", { state: { id: props.id, name:props.title } });
     }
     const handleDelete = (event) => {
         // stops the click from bubbling into the edit click functionality

--- a/frontend/src/components/Card.js
+++ b/frontend/src/components/Card.js
@@ -16,7 +16,11 @@ function Card(props){
             navigate("/editaudio", { state: { id: props.id, name:props.title } });
         }
     }
-    const handleDelete = () => {
+    const handleDelete = (event) => {
+        // stops the click from bubbling into the edit click functionality
+        event.stopPropagation(); 
+        event.nativeEvent.stopImmediatePropagation();
+        
         const mydbref = dbref(db,("users/" + (auth.currentUser ? auth.currentUser.uid : "user") +'/' + props.id))
         remove(mydbref)
     }


### PR DESCRIPTION
This Pull Request fixes the issue of the delete button going to the event page (https://github.com/Adittya-Gupta/Ethos/issues/1). This was done by using the event.stopPropogation function in the delete button handler. I've also added some minor styling to the delete button so that the user can see when they hover over the delete button.

A video of the functionality is below:

https://github.com/Adittya-Gupta/Ethos/assets/85814475/028ce49f-d831-46bf-858f-466422a258f4

